### PR TITLE
Define Base component

### DIFF
--- a/packages/web-ui/src/Base.tsx
+++ b/packages/web-ui/src/Base.tsx
@@ -1,0 +1,27 @@
+/** @jsx jsx */
+// noinspection ES6UnusedImports
+import { jsx } from '@emotion/core';
+import * as React from 'react';
+
+export interface BaseProps {
+  /**
+   * *[Inherited]* A render function or any React type for rendering root component.
+   */
+  render?: React.ReactType;
+
+  /**
+   * For passing through props to root component.
+   */
+  [key: string]: any;
+}
+
+export const Base: React.FunctionComponent<BaseProps> = ({
+  render: Component,
+  ...restProps
+}) => (
+  <Component {...restProps} />
+);
+
+Base.defaultProps = {
+  render: 'div',
+};

--- a/packages/web-ui/src/Hello/index.tsx
+++ b/packages/web-ui/src/Hello/index.tsx
@@ -1,9 +1,9 @@
-/** @jsx jsx */
-import { css, jsx } from '@emotion/core';
+import { css } from '@emotion/core';
 import colors from '@ridi/colors';
 import * as React from 'react';
+import { Base, BaseProps } from '../Base';
 
-export interface HelloProps {
+export interface HelloProps extends BaseProps {
   /**
    * A `string` to be attached before **"Hello"**
    */
@@ -13,27 +13,23 @@ export interface HelloProps {
    * A `string` to be attached after **"Hello"**
    */
   postfix?: string;
-
-  [key: string]: any;
 }
 
 const style = css`
   color: ${colors.dodgerblue_50};
 `;
 
-export const Hello: React.SFC<HelloProps> = ({
+export const Hello: React.FunctionComponent<HelloProps> = ({
   prefix,
   postfix,
   ...restProps
 }) => (
-  <span
-    css={style}
-    {...restProps}
-  >
+  <Base css={style} {...restProps}>
     {prefix}Hello{postfix}
-  </span>
+  </Base>
 );
 
 Hello.defaultProps = {
   postfix: '!',
+  render: 'span',
 };

--- a/packages/web-ui/src/HelloWorld/index.tsx
+++ b/packages/web-ui/src/HelloWorld/index.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react';
+import { Base, BaseProps } from '../Base';
 import { Hello } from '../Hello';
 import { World } from '../World';
 
-export interface HelloWorldProps {
-  [key: string]: any;
-}
+export interface HelloWorldProps extends BaseProps {}
 
-export const HelloWorld: React.SFC<HelloWorldProps> = ({
-  ...restProps
-}) => (
-  <span {...restProps}>
+export const HelloWorld: React.FunctionComponent<HelloWorldProps> = (props) => (
+  <Base {...props}>
     <Hello postfix=" " />
     <World />
-  </span>
+  </Base>
 );
+
+HelloWorld.defaultProps = {
+  render: 'span',
+};

--- a/packages/web-ui/src/Icon/index.tsx
+++ b/packages/web-ui/src/Icon/index.tsx
@@ -1,26 +1,23 @@
 import * as icons from '@ridi/web-icons';
 import * as React from 'react';
+import { Base, BaseProps } from '../Base';
 
 /**
  * @deprecated Use `@ridi/web-icons` directly instead.
  */
-export interface IconProps {
+export interface IconProps extends BaseProps {
   /**
    * Icon name
    */
   name: keyof typeof icons;
-
-  [key: string]: any;
 }
 
 /**
  * @deprecated Use `@ridi/web-icons` directly instead.
  */
-export const Icon: React.SFC<IconProps> = ({
+export const Icon: React.FunctionComponent<IconProps> = ({
   name,
   ...restProps
-}) => {
-  const Component = icons[name];
-
-  return <Component {...restProps} />;
-};
+}) => (
+  <Base render={icons[name]} {...restProps} />
+);

--- a/packages/web-ui/src/World/index.tsx
+++ b/packages/web-ui/src/World/index.tsx
@@ -1,9 +1,9 @@
-/** @jsx jsx */
-import { css, jsx } from '@emotion/core';
+import { css } from '@emotion/core';
 import colors from '@ridi/colors';
 import * as React from 'react';
+import { Base, BaseProps } from '../Base';
 
-export interface WorldProps {
+export interface WorldProps extends BaseProps {
   /**
    * A `string` to be attached before **"World"**
    */
@@ -13,27 +13,23 @@ export interface WorldProps {
    * A `string` to be attached after **"World"**
    */
   postfix?: string;
-
-  [key: string]: any;
 }
 
 const style = css({
   color: colors.orange_50,
 });
 
-export const World: React.SFC<WorldProps> = ({
+export const World: React.FunctionComponent<WorldProps> = ({
   prefix,
   postfix,
   ...restProps
 }) => (
-  <span
-    css={style}
-    {...restProps}
-  >
+  <Base css={style} {...restProps}>
     {prefix}World{postfix}
-  </span>
+  </Base>
 );
 
 World.defaultProps = {
   postfix: '!',
+  render: 'span',
 };

--- a/packages/web-ui/tslint.json
+++ b/packages/web-ui/tslint.json
@@ -7,6 +7,7 @@
     "tslint-plugin-prettier"
   ],
   "rules": {
+    "no-empty-interface": false,
     "trailing-comma": [
       true,
       {


### PR DESCRIPTION
Boilerplate를 줄이기 위한 `Base` 컴포넌트를 작성했습니다.

> [emotion 라이브러리의 `css` prop](https://emotion.sh/docs/css-prop)을 사용하면서 `<></>` syntax를 쓸 수 없었지만 jsx pragma를 `Base` 컴포넌트로 옮기면서 문제가 해결되었습니다. ✨ 