### PR TITLE
Add webpack target `node`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Implement `Options` component. (#33)
+- Add webpack target `node` (#36)
 
 ## [0.0.1] - 2019-01-18
 - Initial release.

--- a/packages/web-ui/src/Book/LandscapeBook/styles.ts
+++ b/packages/web-ui/src/Book/LandscapeBook/styles.ts
@@ -1,4 +1,3 @@
-import css from "@emotion/css";
 import { TextAlignProperty } from "csstype";
 
 export const landscapeBook = {

--- a/packages/web-ui/styleguide.config.js
+++ b/packages/web-ui/styleguide.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const { parse: propsParser } = require('react-docgen-typescript');
-const webpackConfig = require('./webpack.config');
+const webpackConfig = require('./webpack.config.web');
 const pkg = require('./package.json');
 
 module.exports = {

--- a/packages/web-ui/webpack.config.common.js
+++ b/packages/web-ui/webpack.config.common.js
@@ -1,0 +1,54 @@
+const CleanWebpackPlugin = require('clean-webpack-plugin');
+const { CheckerPlugin } = require('awesome-typescript-loader');
+const path = require('path');
+
+const srcDir = path.join(__dirname, 'src');
+const outDir = path.join(__dirname, 'dist');
+
+module.exports = {
+  entry: path.join(srcDir, 'index.ts'),
+  output: {
+    path: outDir,
+  },
+  mode: 'production',
+  devtool: 'source-map',
+  externals: {
+    react: 'react',
+    'react-dom': 'react-dom',
+    'react-dom/server': 'react-dom/server',
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js', '.jsx'],
+  },
+  module: {
+    rules: [
+      {
+        enforce: 'pre',
+        test: /\.(ts|tsx)$/,
+        include: srcDir,
+        use: ['tslint-loader'],
+      },
+      {
+        test: /\.(ts|tsx)$/,
+        include: srcDir,
+        use: ['babel-loader', 'awesome-typescript-loader'],
+      },
+      {
+        test: /\.svg$/,
+        use: [
+          {
+            loader: '@svgr/webpack',
+            options: {
+              prettier: false,
+              svgo: false,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new CleanWebpackPlugin([outDir]),
+    new CheckerPlugin(),
+  ],
+};

--- a/packages/web-ui/webpack.config.js
+++ b/packages/web-ui/webpack.config.js
@@ -7,6 +7,7 @@ const outDir = path.join(__dirname, 'dist');
 
 module.exports = {
   entry: path.join(srcDir, 'index.ts'),
+  target: 'node',
   output: {
     path: outDir,
     filename: 'index.js',

--- a/packages/web-ui/webpack.config.js
+++ b/packages/web-ui/webpack.config.js
@@ -1,57 +1,7 @@
-const CleanWebpackPlugin = require('clean-webpack-plugin');
-const { CheckerPlugin } = require('awesome-typescript-loader');
-const path = require('path');
+const webConfig = require('./webpack.config.web');
+const nodeConfig = require('./webpack.config.node');
 
-const srcDir = path.join(__dirname, 'src');
-const outDir = path.join(__dirname, 'dist');
-
-module.exports = {
-  entry: path.join(srcDir, 'index.ts'),
-  target: 'node',
-  output: {
-    path: outDir,
-    filename: 'index.js',
-    libraryTarget: 'commonjs2',
-  },
-  mode: 'production',
-  devtool: 'source-map',
-  externals: {
-    react: 'react',
-    'react-dom': 'react-dom',
-    'react-dom/server': 'react-dom/server',
-  },
-  resolve: {
-    extensions: ['.ts', '.tsx', '.js', '.jsx'],
-  },
-  module: {
-    rules: [
-      {
-        enforce: 'pre',
-        test: /\.(ts|tsx)$/,
-        include: srcDir,
-        use: ['tslint-loader'],
-      },
-      {
-        test: /\.(ts|tsx)$/,
-        include: srcDir,
-        use: ['babel-loader', 'awesome-typescript-loader'],
-      },
-      {
-        test: /\.svg$/,
-        use: [
-          {
-            loader: '@svgr/webpack',
-            options: {
-              prettier: false,
-              svgo: false,
-            },
-          },
-        ],
-      },
-    ],
-  },
-  plugins: [
-    new CleanWebpackPlugin([outDir]),
-    new CheckerPlugin(),
-  ],
-};
+module.exports = [
+  webConfig,
+  nodeConfig,
+];

--- a/packages/web-ui/webpack.config.node.js
+++ b/packages/web-ui/webpack.config.node.js
@@ -1,0 +1,13 @@
+const _ = require('lodash');
+const commonConfig = require('./webpack.config.common');
+
+module.exports = _.merge({},
+  commonConfig,
+  {
+    target: 'node',
+    output: {
+      filename: 'index.node.js',
+      libraryTarget: 'commonjs2',
+    },
+  },
+);

--- a/packages/web-ui/webpack.config.web.js
+++ b/packages/web-ui/webpack.config.web.js
@@ -1,0 +1,12 @@
+const _ = require('lodash');
+const commonConfig = require('./webpack.config.common');
+
+module.exports = _.merge({},
+  commonConfig,
+  {
+    output: {
+      filename: 'index.js',
+      libraryTarget: 'commonjs2',
+    },
+  },
+);


### PR DESCRIPTION
Server Side Rendering 시 `document` 객체가 `undefined`인 문제를 해결하기 위해 webpack target에 `node`를 추가했습니다.

참고 이슈: https://github.com/emotion-js/emotion/issues/1113