### PR TITLE
Remove Subpath for Apex Domain

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,5 @@
 # Site settings
 title: RIDI Design System
-baseurl: "/design-system"
 
 # Build settings
 collections:

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -15,7 +15,7 @@
   <meta name="theme-color" content="#ffffff">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta property="og:title" content="RIDI Design System" />
-  <meta property="og:url" content="https://ridi.github.io/design-system/" />
+  <meta property="og:url" content="https://ridi.design" />
   <meta property="og:type" content="website" />
   <meta property="og:description" content="리디를 디자인하기 위한 단 하나의 시스템." />
   <meta property="og:image" content="{{ '/assets/img/OG.png'| relative_url }}">

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,17 +2,11 @@
 
 [build]
   base = "/"
-  publish = "netlify/"
+  publish = "docs/_site/"
   environment = { NODE_VERSION = "10", RUBY_VERSION = "2.5" }
   command = '''
   yarn build \
   && cp -a ./package-explorer/dist/. ./docs/packages \
   && cd docs \
   && yarn install \
-  && yarn build \
-  && mkdir -p ../netlify/design-system \
-  && cp -a ./_site/. ../netlify/design-system'''
-
-[[redirects]]
-  from = "/*"
-  to = "/design-system"
+  && yarn build'''


### PR DESCRIPTION
새 도메인 `ridi.design` 연결 후에는 기존 웹사이트 주소(`https://ridi.github.io/design-system`)의 서브패스(`design-system`) 때문에 필요하던 설정이  제거돼야합니다.
따라서 jekyll과 netlify 설정에 해당 사항을 적용했습니다.