### PR TITLE
Fix layout issue of Thumbnail

### DIFF
--- a/packages/web-ui/src/Book/LandscapeBook/index.tsx
+++ b/packages/web-ui/src/Book/LandscapeBook/index.tsx
@@ -21,7 +21,6 @@ export const LandscapeBook: React.FunctionComponent<LandscapeBookProps> = (props
   const {
     additionalButton,
     additionalMetadata,
-    addMaxHeight = false,
     adultBadge,
     annotations = {
       bookMarkCount: 0,
@@ -53,6 +52,7 @@ export const LandscapeBook: React.FunctionComponent<LandscapeBookProps> = (props
     unitBook = false,
     unitBookCount,
     updateBadge,
+    useMaxHeight = false,
     ...extraProps
   } = props;
 
@@ -65,7 +65,6 @@ export const LandscapeBook: React.FunctionComponent<LandscapeBookProps> = (props
       <div className="LandscapeBook_Thumbnail" css={styles.thumbnail}>
         <Book.Thumbnail
           adultBadge={adultBadge}
-          addMaxHeight={addMaxHeight}
           notAvailable={notAvailable}
           onSelectedChange={onSelectedChange}
           readingStatus={readingStatus}
@@ -77,6 +76,7 @@ export const LandscapeBook: React.FunctionComponent<LandscapeBookProps> = (props
           thumbnailUrl={thumbnailUrl}
           thumbnailWidth={thumbnailWidth}
           updateBadge={updateBadge}
+          useMaxHeight={useMaxHeight}
           viewType={Book.ViewType.Landscape}
         />
       </div>

--- a/packages/web-ui/src/Book/LandscapeBook/index.tsx
+++ b/packages/web-ui/src/Book/LandscapeBook/index.tsx
@@ -21,6 +21,7 @@ export const LandscapeBook: React.FunctionComponent<LandscapeBookProps> = (props
   const {
     additionalButton,
     additionalMetadata,
+    addMaxHeight = false,
     adultBadge,
     annotations = {
       bookMarkCount: 0,
@@ -64,6 +65,7 @@ export const LandscapeBook: React.FunctionComponent<LandscapeBookProps> = (props
       <div className="LandscapeBook_Thumbnail" css={styles.thumbnail}>
         <Book.Thumbnail
           adultBadge={adultBadge}
+          addMaxHeight={addMaxHeight}
           notAvailable={notAvailable}
           onSelectedChange={onSelectedChange}
           readingStatus={readingStatus}

--- a/packages/web-ui/src/Book/LandscapeBook/index.tsx
+++ b/packages/web-ui/src/Book/LandscapeBook/index.tsx
@@ -47,7 +47,7 @@ export const LandscapeBook: React.FunctionComponent<LandscapeBookProps> = (props
     thumbnailLink,
     thumbnailTitle,
     thumbnailUrl,
-    thumbnailWidth = '100%',
+    thumbnailWidth,
     title,
     unitBook = false,
     unitBookCount,

--- a/packages/web-ui/src/Book/PortraitBook/index.tsx
+++ b/packages/web-ui/src/Book/PortraitBook/index.tsx
@@ -40,7 +40,7 @@ export const PortraitBook: React.FunctionComponent<PortraitBookProps> = (props) 
     thumbnailLink,
     thumbnailTitle,
     thumbnailUrl,
-    thumbnailWidth = '100%',
+    thumbnailWidth,
     title,
     unitBook = false,
     unitBookCount,
@@ -54,13 +54,14 @@ export const PortraitBook: React.FunctionComponent<PortraitBookProps> = (props) 
       className={classNames(['PortraitBook', className])}
       {...extraProps}
     >
-      <div className="PortraitBook_Thumbnail" css={styles.thumbnail}>
+      <div className="PortraitBook_Thumbnail" css={styles.thumbnail(thumbnailWidth)}>
         <Book.Thumbnail
           adultBadge={adultBadge}
           downloadProgress={downloadProgress}
           downloadStatus={downloadStatus}
           expired={expired}
           expiredAt={expiredAt}
+          addMaxHeight={true}
           notAvailable={notAvailable}
           onSelectedChange={onSelectedChange}
           readingProgress={readingProgress}

--- a/packages/web-ui/src/Book/PortraitBook/index.tsx
+++ b/packages/web-ui/src/Book/PortraitBook/index.tsx
@@ -22,7 +22,6 @@ export const PortraitBook: React.FunctionComponent<PortraitBookProps> = (props) 
   const {
     additionalButton,
     additionalMetadata,
-    addMaxHeight = true,
     adultBadge,
     author,
     className,
@@ -48,10 +47,11 @@ export const PortraitBook: React.FunctionComponent<PortraitBookProps> = (props) 
     unitBook = false,
     unitBookCount,
     updateBadge,
+    useMaxHeight = true,
     ...extraProps
   } = props;
 
-  const { isUnRead, isOpened } = getReadingStatus(readingStatus, ViewType.Portrait);
+  const { isUnread, isOpened } = getReadingStatus(readingStatus, ViewType.Portrait);
 
   return (
     <div
@@ -59,9 +59,8 @@ export const PortraitBook: React.FunctionComponent<PortraitBookProps> = (props) 
       className={classNames(['PortraitBook', className])}
       {...extraProps}
     >
-      <div className="PortraitBook_Thumbnail" css={styles.portraitBookThumbnailLayout(thumbnailWidth, isUnRead, isOpened)}>
+      <div className="PortraitBook_Thumbnail" css={styles.portraitBookThumbnailLayout(thumbnailWidth, isUnread, isOpened)}>
         <Book.Thumbnail
-          addMaxHeight={addMaxHeight}
           adultBadge={adultBadge}
           downloadProgress={downloadProgress}
           downloadStatus={downloadStatus}
@@ -82,6 +81,7 @@ export const PortraitBook: React.FunctionComponent<PortraitBookProps> = (props) 
           unitBook={unitBook}
           unitBookCount={unitBookCount}
           updateBadge={updateBadge}
+          useMaxHeight={useMaxHeight}
           viewType={Book.ViewType.Portrait}
         />
       </div>

--- a/packages/web-ui/src/Book/PortraitBook/index.tsx
+++ b/packages/web-ui/src/Book/PortraitBook/index.tsx
@@ -3,6 +3,8 @@ import { jsx } from '@emotion/core';
 import classNames from 'classnames';
 import * as React from 'react';
 import { Book } from '../';
+import { ViewType } from '../Book';
+import { getReadingStatus } from '../Thumbnail';
 import * as styles from './styles';
 
 export interface PortraitBookProps extends
@@ -49,13 +51,15 @@ export const PortraitBook: React.FunctionComponent<PortraitBookProps> = (props) 
     ...extraProps
   } = props;
 
+  const { isUnRead, isOpened } = getReadingStatus(readingStatus, ViewType.Portrait);
+
   return (
     <div
       css={[styles.portraitBook(thumbnailWidth), portraitStyles]}
       className={classNames(['PortraitBook', className])}
       {...extraProps}
     >
-      <div className="PortraitBook_Thumbnail" css={styles.thumbnail(thumbnailWidth)}>
+      <div className="PortraitBook_Thumbnail" css={styles.portraitBookThumbnailLayout(thumbnailWidth, isUnRead, isOpened)}>
         <Book.Thumbnail
           addMaxHeight={addMaxHeight}
           adultBadge={adultBadge}

--- a/packages/web-ui/src/Book/PortraitBook/index.tsx
+++ b/packages/web-ui/src/Book/PortraitBook/index.tsx
@@ -20,6 +20,7 @@ export const PortraitBook: React.FunctionComponent<PortraitBookProps> = (props) 
   const {
     additionalButton,
     additionalMetadata,
+    addMaxHeight = true,
     adultBadge,
     author,
     className,
@@ -56,12 +57,12 @@ export const PortraitBook: React.FunctionComponent<PortraitBookProps> = (props) 
     >
       <div className="PortraitBook_Thumbnail" css={styles.thumbnail(thumbnailWidth)}>
         <Book.Thumbnail
+          addMaxHeight={addMaxHeight}
           adultBadge={adultBadge}
           downloadProgress={downloadProgress}
           downloadStatus={downloadStatus}
           expired={expired}
           expiredAt={expiredAt}
-          addMaxHeight={true}
           notAvailable={notAvailable}
           onSelectedChange={onSelectedChange}
           readingProgress={readingProgress}

--- a/packages/web-ui/src/Book/PortraitBook/styles.ts
+++ b/packages/web-ui/src/Book/PortraitBook/styles.ts
@@ -1,21 +1,20 @@
 import { PositionProperty } from "csstype";
-import { THUMBNAIL_HEIGHT_RATIO } from "../ThumbnailImage/styles";
+import { getMaxHeight } from "../Thumbnail/styles";
 
-export const portraitBook = (thumbnailWidth: number | string) => ({
+export const portraitBook = (thumbnailWidth: number) => ({
   width: thumbnailWidth,
 });
 
-export const thumbnail = {
+export const thumbnail = (thumbnailWidth: number) => ({
   position: 'relative' as PositionProperty,
   lineHeight: 0,
   width: '100%',
-  height: 'auto',
-  paddingBottom: THUMBNAIL_HEIGHT_RATIO,
+  height: getMaxHeight(thumbnailWidth),
   '& .Thumbnail': {
     position: 'absolute' as PositionProperty,
     bottom: 0,
   },
-};
+});
 
 export const metadata = {
   marginTop: 5,

--- a/packages/web-ui/src/Book/PortraitBook/styles.ts
+++ b/packages/web-ui/src/Book/PortraitBook/styles.ts
@@ -1,15 +1,15 @@
 import { PositionProperty } from "csstype";
-import { getMaxHeight } from "../Thumbnail/styles";
+import { getAdditionalPaddingTop, getMaxHeight } from "../Thumbnail/styles";
 
 export const portraitBook = (thumbnailWidth: number) => ({
   width: thumbnailWidth,
 });
 
-export const thumbnail = (thumbnailWidth: number) => ({
+export const portraitBookThumbnailLayout = (thumbnailWidth: number,  hasUnReadDot: boolean, hasReadingProgressBar: boolean) => ({
   position: 'relative' as PositionProperty,
   lineHeight: 0,
   width: '100%',
-  height: getMaxHeight(thumbnailWidth),
+  height: `${getMaxHeight(thumbnailWidth) + getAdditionalPaddingTop(hasUnReadDot, hasReadingProgressBar)}px`,
   '& .Thumbnail': {
     position: 'absolute' as PositionProperty,
     bottom: 0,

--- a/packages/web-ui/src/Book/PortraitBook/styles.ts
+++ b/packages/web-ui/src/Book/PortraitBook/styles.ts
@@ -5,11 +5,11 @@ export const portraitBook = (thumbnailWidth: number) => ({
   width: thumbnailWidth,
 });
 
-export const portraitBookThumbnailLayout = (thumbnailWidth: number,  hasUnReadDot: boolean, hasReadingProgressBar: boolean) => ({
+export const portraitBookThumbnailLayout = (thumbnailWidth: number,  hasUnreadDot: boolean, hasReadingProgressBar: boolean) => ({
   position: 'relative' as PositionProperty,
   lineHeight: 0,
   width: '100%',
-  height: `${getMaxHeight(thumbnailWidth) + getAdditionalPaddingTop(hasUnReadDot, hasReadingProgressBar)}px`,
+  height: `${getMaxHeight(thumbnailWidth) + getAdditionalPaddingTop(hasUnreadDot, hasReadingProgressBar)}px`,
   '& .Thumbnail': {
     position: 'absolute' as PositionProperty,
     bottom: 0,

--- a/packages/web-ui/src/Book/README.md
+++ b/packages/web-ui/src/Book/README.md
@@ -44,10 +44,10 @@ import { Book } from '@ridi/web-ui';
     marginLeft: 20,
   }}>
     <Book.Thumbnail
+      addMaxHeight
       thumbnailTitle="데미안"
       thumbnailUrl="https://misc.ridibooks.com/cover/509000028/large?dpi=xhdpi"
       thumbnailWidth={100}
-      addMaxHeight
     />
     <p>max-height on</p>
   </div>

--- a/packages/web-ui/src/Book/README.md
+++ b/packages/web-ui/src/Book/README.md
@@ -4,7 +4,10 @@
 import { Book } from '@ridi/web-ui';
 
 <div style={{ width: '200px' }}>
-  <Book.Thumbnail thumbnailUrl="https://misc.ridibooks.com/cover/204000008/xxlarge?dpi=xxhdpi" />
+  <Book.Thumbnail
+    thumbnailUrl="https://misc.ridibooks.com/cover/204000008/xxlarge?dpi=xxhdpi"
+    thumbnailWidth={200} // pixel only
+  />
 </div>
 ```
 
@@ -14,13 +17,41 @@ import { Book } from '@ridi/web-ui';
 <Book.Thumbnail
   thumbnailTitle="그레이의 50가지 그림자" // default '도서 표지'
   thumbnailUrl="https://misc.ridibooks.com/cover/862000002/xxlarge?dpi=xxhdpi"
-  thumbnailWidth={150} // default '100%'
+  thumbnailWidth={150}
   viewType={Book.ViewType.Portrait} // default ViewType.Portrait
-  
+
   updateBadge
   adultBadge
   thumbnailLink={<a href="/">Thumbnail link</a>}
 />
+```
+
+```jsx
+import { Book } from '@ridi/web-ui';
+<div>
+  <div style={{
+    display: 'inline-block',
+  }}>
+    <Book.Thumbnail
+      thumbnailTitle="데미안"
+      thumbnailUrl="https://misc.ridibooks.com/cover/509000028/large?dpi=xhdpi"
+      thumbnailWidth={100}
+    />
+    <p>max-height off</p>
+  </div>
+  <div style={{
+    display: 'inline-block',
+    marginLeft: 20,
+  }}>
+    <Book.Thumbnail
+      thumbnailTitle="데미안"
+      thumbnailUrl="https://misc.ridibooks.com/cover/509000028/large?dpi=xhdpi"
+      thumbnailWidth={100}
+      addMaxHeight
+    />
+    <p>max-height on</p>
+  </div>
+</div>
 ```
 
 ```jsx

--- a/packages/web-ui/src/Book/README.md
+++ b/packages/web-ui/src/Book/README.md
@@ -44,7 +44,7 @@ import { Book } from '@ridi/web-ui';
     marginLeft: 20,
   }}>
     <Book.Thumbnail
-      addMaxHeight
+      useMaxHeight
       thumbnailTitle="데미안"
       thumbnailUrl="https://misc.ridibooks.com/cover/509000028/large?dpi=xhdpi"
       thumbnailWidth={100}

--- a/packages/web-ui/src/Book/ReadingProgressBar/styles.ts
+++ b/packages/web-ui/src/Book/ReadingProgressBar/styles.ts
@@ -2,11 +2,19 @@ import { PositionProperty } from 'csstype';
 import { merge } from 'lodash';
 import { resetFont, resetLayout } from "../../styles";
 
+const progresssBarheight = 4;
+const marginBottomForThumbnailInside = 8;
+
+export const ProgressBarOutterHeight = progresssBarheight + marginBottomForThumbnailInside;
 export const readingProgressBar = merge({}, resetLayout, {
   position: 'relative',
   lineHeight: 0,
   '.Thumbnail & ': {
-    marginBottom: 8,
+    fontSize: 0,
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    width: '100%',
   },
 });
 
@@ -38,12 +46,12 @@ export const percentage = merge({}, resetFont, {
 
 export const progressBG = {
   display: 'inline-block',
-  borderRadius: 4,
+  borderRadius: progresssBarheight,
   background: '#d1d5d9',
   overflow: 'hidden',
   position: 'relative' as PositionProperty,
   width: 80,
-  height: 4,
+  height: progresssBarheight,
   '.Thumbnail & ': {
     width: '100%',
   },
@@ -56,7 +64,7 @@ export const progress = {
   top: 0,
   width: 0,
   height: '100%',
-  borderRadius: 4,
+  borderRadius: progresssBarheight,
   background: '#808991',
   color: '#808991',
 };

--- a/packages/web-ui/src/Book/ReadingProgressBar/styles.ts
+++ b/packages/web-ui/src/Book/ReadingProgressBar/styles.ts
@@ -2,10 +2,10 @@ import { PositionProperty } from 'csstype';
 import { merge } from 'lodash';
 import { resetFont, resetLayout } from "../../styles";
 
-const progresssBarheight = 4;
-const marginBottomForThumbnailInside = 8;
+const PROGRESS_BAR_HEIGHT = 4;
+const MARGIN_BOTTOM_FOR_THUMBNAIL_INSIDE = 8;
 
-export const ProgressBarOutterHeight = progresssBarheight + marginBottomForThumbnailInside;
+export const ProgressBarOutterHeight = PROGRESS_BAR_HEIGHT + MARGIN_BOTTOM_FOR_THUMBNAIL_INSIDE;
 export const readingProgressBar = merge({}, resetLayout, {
   position: 'relative',
   lineHeight: 0,
@@ -46,12 +46,12 @@ export const percentage = merge({}, resetFont, {
 
 export const progressBG = {
   display: 'inline-block',
-  borderRadius: progresssBarheight,
+  borderRadius: PROGRESS_BAR_HEIGHT,
   background: '#d1d5d9',
   overflow: 'hidden',
   position: 'relative' as PositionProperty,
   width: 80,
-  height: progresssBarheight,
+  height: PROGRESS_BAR_HEIGHT,
   '.Thumbnail & ': {
     width: '100%',
   },
@@ -64,7 +64,7 @@ export const progress = {
   top: 0,
   width: 0,
   height: '100%',
-  borderRadius: progresssBarheight,
+  borderRadius: PROGRESS_BAR_HEIGHT,
   background: '#808991',
   color: '#808991',
 };

--- a/packages/web-ui/src/Book/Thumbnail/index.tsx
+++ b/packages/web-ui/src/Book/Thumbnail/index.tsx
@@ -36,6 +36,7 @@ export interface ThumbnailProps extends
     className?: string;
     expired?: boolean;
     expiredAt?: string;
+    addMaxHeight?: boolean;
     notAvailable?: boolean;
     onSelectedChange?: (e: React.SyntheticEvent<any>) => void;
     selectMode?: boolean;
@@ -107,13 +108,14 @@ export const Thumbnail: React.FunctionComponent<ThumbnailProps> = (props) => {
     unitBookCount,
     updateBadge = false,
     viewType = ViewType.Portrait,
+    addMaxHeight = false,
     ...extraProps
   } = props;
-  const childrenSize = thumbnailChildrenSize ? thumbnailChildrenSize : thumbnailWidth ? getThumbnailChildrenSize(thumbnailWidth) : ThumbnailChildrenSize.Medium;
+  const childrenSize = thumbnailChildrenSize ? thumbnailChildrenSize : getThumbnailChildrenSize(thumbnailWidth);
 
   return (
     <div
-      css={[styles.thumbnail, thumbnailWidth && styles.thumbnailWidth(thumbnailWidth)]}
+      css={[styles.thumbnail, styles.thumbnailSize(thumbnailWidth, addMaxHeight)]}
       className={classNames(['Thumbnail', className])}
       {...extraProps}
     >

--- a/packages/web-ui/src/Book/Thumbnail/index.tsx
+++ b/packages/web-ui/src/Book/Thumbnail/index.tsx
@@ -31,12 +31,12 @@ export interface ThumbnailProps extends
   DownloadButtonProps,
   ReadingProgressBarProps,
   ThumbnailImageProps {
+    addMaxHeight?: boolean;
     adultBadge?: boolean;
     children?: React.ReactNode;
     className?: string;
     expired?: boolean;
     expiredAt?: string;
-    addMaxHeight?: boolean;
     notAvailable?: boolean;
     onSelectedChange?: (e: React.SyntheticEvent<any>) => void;
     selectMode?: boolean;
@@ -85,6 +85,7 @@ const getThumbnailChildrenSize = (width: string | number) => {
 
 export const Thumbnail: React.FunctionComponent<ThumbnailProps> = (props) => {
   const {
+    addMaxHeight = false,
     adultBadge = false,
     children,
     className,
@@ -108,7 +109,6 @@ export const Thumbnail: React.FunctionComponent<ThumbnailProps> = (props) => {
     unitBookCount,
     updateBadge = false,
     viewType = ViewType.Portrait,
-    addMaxHeight = false,
     ...extraProps
   } = props;
   const childrenSize = thumbnailChildrenSize ? thumbnailChildrenSize : getThumbnailChildrenSize(thumbnailWidth);

--- a/packages/web-ui/src/Book/Thumbnail/index.tsx
+++ b/packages/web-ui/src/Book/Thumbnail/index.tsx
@@ -19,7 +19,7 @@ import {
   ThumbnailImageProps,
   UnitBookCountProps,
   UnitBookDownloading,
-  UnReadDot,
+  UnreadDot,
   UpdateBadge,
   ViewType,
 } from '../Book';
@@ -31,7 +31,6 @@ export interface ThumbnailProps extends
   DownloadButtonProps,
   ReadingProgressBarProps,
   ThumbnailImageProps {
-    addMaxHeight?: boolean;
     adultBadge?: boolean;
     children?: React.ReactNode;
     className?: string;
@@ -48,6 +47,7 @@ export interface ThumbnailProps extends
     unitBook?: boolean;
     unitBookCount?: React.ReactElement<UnitBookCountProps>;
     updateBadge?: boolean;
+    useMaxHeight?: boolean;
     viewType?: ViewType;
     [extraKey: string]: any;
   }
@@ -84,13 +84,12 @@ const getThumbnailChildrenSize = (width: string | number) => {
 };
 
 export const getReadingStatus = (readingStatus: ReadingStatus, viewType: ViewType) => ({
-  isUnRead: readingStatus && readingStatus === ReadingStatus.New,
+  isUnread: readingStatus && readingStatus === ReadingStatus.New,
   isOpened: readingStatus && readingStatus === ReadingStatus.Opened && viewType === ViewType.Portrait,
 });
 
 export const Thumbnail: React.FunctionComponent<ThumbnailProps> = (props) => {
   const {
-    addMaxHeight = false,
     adultBadge = false,
     children,
     className,
@@ -113,18 +112,19 @@ export const Thumbnail: React.FunctionComponent<ThumbnailProps> = (props) => {
     unitBook = false,
     unitBookCount,
     updateBadge = false,
+    useMaxHeight = false,
     viewType = ViewType.Portrait,
     ...extraProps
   } = props;
   const childrenSize = thumbnailChildrenSize ? thumbnailChildrenSize : getThumbnailChildrenSize(thumbnailWidth);
-  const { isUnRead, isOpened } = getReadingStatus(readingStatus, viewType);
+  const { isUnread, isOpened } = getReadingStatus(readingStatus, viewType);
   return (
     <div
-      css={styles.thumbnailLayout(thumbnailWidth, addMaxHeight, isUnRead, isOpened)}
+      css={styles.thumbnailLayout(thumbnailWidth, useMaxHeight, isUnread, isOpened)}
       className={classNames(['Thumbnail', className])}
       {...extraProps}
     >
-      {isUnRead && <UnReadDot />}
+      {isUnread && <UnreadDot />}
       {isOpened && <ReadingProgressBar readingProgress={readingProgress} />}
       <div css={styles.thumbnailImageWrapper}>
         {selectMode &&

--- a/packages/web-ui/src/Book/Thumbnail/index.tsx
+++ b/packages/web-ui/src/Book/Thumbnail/index.tsx
@@ -83,6 +83,11 @@ const getThumbnailChildrenSize = (width: string | number) => {
   }
 };
 
+export const getReadingStatus = (readingStatus: ReadingStatus, viewType: ViewType) => ({
+  isUnRead: readingStatus && readingStatus === ReadingStatus.New,
+  isOpened: readingStatus && readingStatus === ReadingStatus.Opened && viewType === ViewType.Portrait,
+});
+
 export const Thumbnail: React.FunctionComponent<ThumbnailProps> = (props) => {
   const {
     addMaxHeight = false,
@@ -112,20 +117,15 @@ export const Thumbnail: React.FunctionComponent<ThumbnailProps> = (props) => {
     ...extraProps
   } = props;
   const childrenSize = thumbnailChildrenSize ? thumbnailChildrenSize : getThumbnailChildrenSize(thumbnailWidth);
-
+  const { isUnRead, isOpened } = getReadingStatus(readingStatus, viewType);
   return (
     <div
-      css={[styles.thumbnail, styles.thumbnailSize(thumbnailWidth, addMaxHeight)]}
+      css={styles.thumbnailLayout(thumbnailWidth, addMaxHeight, isUnRead, isOpened)}
       className={classNames(['Thumbnail', className])}
       {...extraProps}
     >
-      {readingStatus && <React.Fragment>
-        {readingStatus === ReadingStatus.New ? (
-          <UnReadDot />
-        ) : readingStatus === ReadingStatus.Opened && viewType === ViewType.Portrait ? (
-          <ReadingProgressBar readingProgress={readingProgress} />
-        ) : null}
-      </React.Fragment>}
+      {isUnRead && <UnReadDot />}
+      {isOpened && <ReadingProgressBar readingProgress={readingProgress} />}
       <div css={styles.thumbnailImageWrapper}>
         {selectMode &&
           <ThumbnailCheckbox

--- a/packages/web-ui/src/Book/Thumbnail/styles.ts
+++ b/packages/web-ui/src/Book/Thumbnail/styles.ts
@@ -1,10 +1,10 @@
 import { PositionProperty } from "csstype";
 import { ProgressBarOutterHeight } from "../ReadingProgressBar/styles";
 import { THUMBNAIL_HEIGHT_RATIO } from "../ThumbnailImage/styles";
-import { UnReadDotOutterHeight } from "../UnreadDot/styles";
+import { UnreadDotOutterHeight } from "../UnreadDot/styles";
 
 export const getMaxHeight = (width: number) => Math.floor(width * THUMBNAIL_HEIGHT_RATIO / 100);
-export const getAdditionalPaddingTop = (hasUnReadDot: boolean, hasReadingProgressBar: boolean) => hasUnReadDot ? UnReadDotOutterHeight : hasReadingProgressBar ? ProgressBarOutterHeight : 0;
+export const getAdditionalPaddingTop = (hasUnreadDot: boolean, hasReadingProgressBar: boolean) => hasUnreadDot ? UnreadDotOutterHeight : hasReadingProgressBar ? ProgressBarOutterHeight : 0;
 
 export const thumbnail = {
   lineHeight: 0,
@@ -12,11 +12,11 @@ export const thumbnail = {
   position: 'relative' as PositionProperty,
 };
 
-export const thumbnailLayout = (width: number, addMaxHeight: boolean, hasUnReadDot: boolean, hasReadingProgressBar: boolean) => ({
+export const thumbnailLayout = (width: number, useMaxHeight: boolean, hasUnreadDot: boolean, hasReadingProgressBar: boolean) => ({
   ...thumbnail,
   width,
-  maxHeight: addMaxHeight ? `${getMaxHeight(width)}px` : null,
-  paddingTop: `${getAdditionalPaddingTop(hasUnReadDot, hasReadingProgressBar)}px`,
+  maxHeight: useMaxHeight ? `${getMaxHeight(width)}px` : null,
+  paddingTop: `${getAdditionalPaddingTop(hasUnreadDot, hasReadingProgressBar)}px`,
 });
 
 export const thumbnailDimmed = {

--- a/packages/web-ui/src/Book/Thumbnail/styles.ts
+++ b/packages/web-ui/src/Book/Thumbnail/styles.ts
@@ -1,14 +1,17 @@
 import { PositionProperty } from "csstype";
+import { THUMBNAIL_HEIGHT_RATIO } from "../ThumbnailImage/styles";
+
+export const getMaxHeight = (width: number) => `${Math.floor(width * THUMBNAIL_HEIGHT_RATIO / 100)}px`;
 
 export const thumbnail = {
   lineHeight: 0,
+  maxHeight: 'inherit',
 };
 
-export const thumbnailWidth = (width: number | string) => {
-  return ({
-    width,
-  });
-};
+export const thumbnailSize = (width: number, addMaxHeight: boolean) => ({
+  width,
+  maxHeight: addMaxHeight ? getMaxHeight(width) : null,
+});
 
 export const thumbnailDimmed = {
   display: 'block',
@@ -25,6 +28,7 @@ export const thumbnailImageWrapper = {
   position: 'relative' as PositionProperty,
   fontSize: 0,
   lineHeight: 0,
+  maxHeight: 'inherit',
 };
 
 export const thumbnailLink = {

--- a/packages/web-ui/src/Book/Thumbnail/styles.ts
+++ b/packages/web-ui/src/Book/Thumbnail/styles.ts
@@ -1,16 +1,22 @@
 import { PositionProperty } from "csstype";
+import { ProgressBarOutterHeight } from "../ReadingProgressBar/styles";
 import { THUMBNAIL_HEIGHT_RATIO } from "../ThumbnailImage/styles";
+import { UnReadDotOutterHeight } from "../UnreadDot/styles";
 
-export const getMaxHeight = (width: number) => `${Math.floor(width * THUMBNAIL_HEIGHT_RATIO / 100)}px`;
+export const getMaxHeight = (width: number) => Math.floor(width * THUMBNAIL_HEIGHT_RATIO / 100);
+export const getAdditionalPaddingTop = (hasUnReadDot: boolean, hasReadingProgressBar: boolean) => hasUnReadDot ? UnReadDotOutterHeight : hasReadingProgressBar ? ProgressBarOutterHeight : 0;
 
 export const thumbnail = {
   lineHeight: 0,
   maxHeight: 'inherit',
+  position: 'relative' as PositionProperty,
 };
 
-export const thumbnailSize = (width: number, addMaxHeight: boolean) => ({
+export const thumbnailLayout = (width: number, addMaxHeight: boolean, hasUnReadDot: boolean, hasReadingProgressBar: boolean) => ({
+  ...thumbnail,
   width,
-  maxHeight: addMaxHeight ? getMaxHeight(width) : null,
+  maxHeight: addMaxHeight ? `${getMaxHeight(width)}px` : null,
+  paddingTop: `${getAdditionalPaddingTop(hasUnReadDot, hasReadingProgressBar)}px`,
 });
 
 export const thumbnailDimmed = {

--- a/packages/web-ui/src/Book/ThumbnailImage/index.tsx
+++ b/packages/web-ui/src/Book/ThumbnailImage/index.tsx
@@ -6,8 +6,8 @@ import * as styles from './styles';
 
 export interface ThumbnailImageProps {
   thumbnailUrl: string;
-  thumbnailTitle?: string;
-  thumbnailWidth?: number | string;
+  thumbnailWidth: number; // pixel only
+  thumbnailTitle?: string;  
   className?: string;
 }
 

--- a/packages/web-ui/src/Book/ThumbnailImage/styles.ts
+++ b/packages/web-ui/src/Book/ThumbnailImage/styles.ts
@@ -1,12 +1,13 @@
 import { BoxSizingProperty, PositionProperty } from "csstype";
 
-export const THUMBNAIL_HEIGHT_RATIO = '162%'; // width : height = 1: 1.618
-export const THUMBNAIL_SKELETON_HEIGHT_RATIO = '142%';
+export const THUMBNAIL_HEIGHT_RATIO = 162; // width : height = 1: 1.618
+export const THUMBNAIL_SKELETON_HEIGHT_RATIO = 142;
 
 export const thumbnailImage = {
   display: 'inline-block',
   position: 'relative' as PositionProperty,
   lineHeight: 0,
+  maxHeight: 'inherit',
   '&::after': {
     display: 'block',
     boxSizing: 'border-box' as BoxSizingProperty,
@@ -27,13 +28,14 @@ export const thumbnailImage = {
   },
 };
 
-export const image = (isImageLoaded : boolean, thumbnailWidth : string | number = '100%') => {
+export const image = (isImageLoaded : boolean, thumbnailWidth : number) => {
   const backgroundImage = !isImageLoaded ? 'linear-gradient(147deg, #e6e8eb, #edeff2 55%, #e6e8eb)' : null;
-  const paddingBottom = !isImageLoaded ? THUMBNAIL_SKELETON_HEIGHT_RATIO : null;
+  const paddingBottom = !isImageLoaded ? `${THUMBNAIL_SKELETON_HEIGHT_RATIO}%` : null;
   const height = !isImageLoaded ? 0 : null;
   return ({
     display: 'block',
     width: thumbnailWidth,
+    maxHeight: 'inherit',
     height,
     paddingBottom,
     backgroundImage,

--- a/packages/web-ui/src/Book/UnreadDot/index.tsx
+++ b/packages/web-ui/src/Book/UnreadDot/index.tsx
@@ -3,6 +3,6 @@ import { jsx } from '@emotion/core';
 import * as React from 'react';
 import * as styles from './styles';
 
-export const UnReadDot: React.FunctionComponent = () => (
-  <p css={styles.unReadDot}>아직 읽지 않은 책</p>
+export const UnreadDot: React.FunctionComponent = () => (
+  <p css={styles.unreadDot}>아직 읽지 않은 책</p>
 );

--- a/packages/web-ui/src/Book/UnreadDot/styles.ts
+++ b/packages/web-ui/src/Book/UnreadDot/styles.ts
@@ -2,20 +2,20 @@ import { PositionProperty } from 'csstype';
 import { merge } from 'lodash';
 import { resetLayout } from "../../styles";
 
-const unReadDotSize = 6;
-const unReadDotMarginBottom = 8;
+const UNREAD_DOT_SIZE = 6;
+const UNREAD_DOT_MARGIN_BOTTOM = 8;
 
-export const unReadDot = merge({}, resetLayout, {
+export const unreadDot = merge({}, resetLayout, {
   position: 'absolute' as PositionProperty,
   left: 0,
   top: 0,
-  width: unReadDotSize,
-  height: unReadDotSize,
-  borderRadius: unReadDotSize,
+  width: UNREAD_DOT_SIZE,
+  height: UNREAD_DOT_SIZE,
+  borderRadius: UNREAD_DOT_SIZE,
   fontSize: 0,
   overflow: 'hidden',
   color: '#339cf2',
   background: '#339cf2',
 });
 
-export const UnReadDotOutterHeight = unReadDotSize + unReadDotMarginBottom;
+export const UnreadDotOutterHeight = UNREAD_DOT_SIZE + UNREAD_DOT_MARGIN_BOTTOM;

--- a/packages/web-ui/src/Book/UnreadDot/styles.ts
+++ b/packages/web-ui/src/Book/UnreadDot/styles.ts
@@ -1,13 +1,21 @@
+import { PositionProperty } from 'csstype';
 import { merge } from 'lodash';
 import { resetLayout } from "../../styles";
 
+const unReadDotSize = 6;
+const unReadDotMarginBottom = 8;
+
 export const unReadDot = merge({}, resetLayout, {
-  width: 6,
-  height: 6,
-  borderRadius: 6,
+  position: 'absolute' as PositionProperty,
+  left: 0,
+  top: 0,
+  width: unReadDotSize,
+  height: unReadDotSize,
+  borderRadius: unReadDotSize,
   fontSize: 0,
   overflow: 'hidden',
   color: '#339cf2',
   background: '#339cf2',
-  marginBottom: 8,
 });
+
+export const UnReadDotOutterHeight = unReadDotSize + unReadDotMarginBottom;


### PR DESCRIPTION
Thumbnail, PortraitBook 의 max-height 관련한 레이아웃 틀어짐 문제를 수정
- width 를 필수값으로 변경
- width 에 따른 일정비율의 높이값을 계산하여 할당
- 새책 dot 이나 독서 진행율 컴포넌트가 있는 경우 padding 값 추가 